### PR TITLE
Close script tags in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ To install manually:
 Should look something like this:
 
 ```
-<script src="https://code.jquery.com/jquery-3.5.1.min.js">
+<script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
 <link rel="stylesheet" media="screen" href="/css/editoria11y.css">
-<script src="/js/editoria11y-prefs.js">
-<script src="/js/editoria11y-localization.js">
-<script src="/js/editoria11y.js">
+<script src="/js/editoria11y-prefs.js"></script>
+<script src="/js/editoria11y-localization.js"></script>
+<script src="/js/editoria11y.js"></script>
 ```
 
 And remember to only call the script for logged-in editors!


### PR DESCRIPTION
Hi, I think this accessibility checker looks amazing! Trying it out now. I just closed the `<script>` tags in the installation instructions so it doesn't trip anyone up. Thanks for making this open source :-)