### PR TITLE
Switch to no-conflict-friendly jQuery init

### DIFF
--- a/js/editoria11y.js
+++ b/js/editoria11y.js
@@ -1,5 +1,5 @@
 // Generic init.
-$( document ).ready(function() {
+jQuery( document ).ready(function($) {
   if (window.navigator.userAgent.match(/MSIE|Trident/) === null) {
     // IE 11 is going to suffer under this load.
     var ed11y = new Ed11y();


### PR DESCRIPTION
Wordpress' bundled version of jQuery runs in [no-conflict mode](https://learn.jquery.com/using-jquery-core/avoid-conflicts-other-libraries/), and changing the `.ready()` to use `jQuery` to pass the `$` in sidesteps the dreaded `$ is not a Function` error while letting the rest of editoria11y's code run without any modification.